### PR TITLE
Adds `BinaryPV` enum to allowed enumerations for `ApplicationTag.ENUMERATED` data entries

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,7 @@ import {
 	type DeviceStatus,
 	type Segmentation,
 	type Reliability,
+	type BinaryPV,
 } from './enum'
 
 export interface EncodeBuffer {
@@ -165,6 +166,7 @@ export interface ApplicationTagValueTypeMap {
 		| DeviceStatus
 		| Segmentation
 		| Reliability
+		| BinaryPV
 	[ApplicationTag.DATE]: Date
 	[ApplicationTag.TIME]: Date
 	[ApplicationTag.OBJECTIDENTIFIER]: BACNetObjectID


### PR DESCRIPTION
This is pretty self-explanatory and simply adds the `BinaryPV` enum to the list of allowed enumerations for `BACNetAppData` instances having `type: ApplicationTag.ENUMERATED`. This is required to safely implement binary objects (binary value, binary input, binary output) whose `Present_Value` property must be set to one of the `BinaryPV` values.